### PR TITLE
Allow world coordinates to be shown for layers

### DIFF
--- a/glue_wwt/viewer/layer_artist.py
+++ b/glue_wwt/viewer/layer_artist.py
@@ -80,7 +80,7 @@ class WWTLayer(LayerArtistBase):
                 try:
                     coord = SkyCoord(ra, dec, unit=(u.deg, u.deg))
                 except ValueError as exc:
-                    self.disable(str(exc))
+                    # self.disable(str(exc))
                     return
 
                 coord_icrs = coord.icrs

--- a/glue_wwt/viewer/state.py
+++ b/glue_wwt/viewer/state.py
@@ -75,10 +75,16 @@ class WWTLayerState(State):
 
         self.ra_att_helper = ComponentIDComboHelper(self, 'ra_att',
                                                     numeric=True,
-                                                    categorical=False)
+                                                    categorical=False,
+                                                    world_coord=True,
+                                                    pixel_coord=False,
+                                                    visible=False)
         self.dec_att_helper = ComponentIDComboHelper(self, 'dec_att',
                                                      numeric=True,
-                                                     categorical=False)
+                                                     categorical=False,
+                                                     world_coord=True,
+                                                     pixel_coord=False,
+                                                     visible=False)
 
         self.add_callback('layer', self._layer_changed)
 


### PR DESCRIPTION
Also don't disable layers for now if SkyCoord is incorrect as glue otherwise makes it impossible to further change the options for the layer.