### PR TITLE
Save WWT interactive figure

### DIFF
--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -10,6 +10,8 @@ from .layer_style_editor import WWTLayerStyleEditor
 # We import the following to register the save tool
 from . import tools  # noqa
 
+from pywwt.qt import WWTQtClient
+
 __all__ = ['WWTDataViewer']
 
 
@@ -26,13 +28,16 @@ class WWTDataViewer(DataViewer):
 
     large_data_size = 100
 
-    subtools = {'save': ['wwt:save']}
+    if hasattr(WWTQtClient, 'save_as_html_bundle'):
+        save_tools = ['wwt:save_image', 'wwt:save_html']
+    else:
+        save_tools = ['wwt:save_image']
+    subtools = {'save': save_tools}
 
     def __init__(self, session, parent=None, state=None):
 
         super(WWTDataViewer, self).__init__(session, parent=parent, state=state)
 
-        from pywwt.qt import WWTQtClient
         self._wwt_client = WWTQtClient()
         self._wwt_client.actual_planet_scale = True
 
@@ -50,6 +55,9 @@ class WWTDataViewer(DataViewer):
         self._wwt_client.widget.page.wwt_ready.connect(self._on_wwt_ready)
 
         self._update_wwt_client(force=True)
+
+        if hasattr(self._wwt_client, 'save_as_html_bundle'):
+            self.subtools['save'].append('wwt:save_html')
 
     def closeEvent(self, event):
         self._wwt_client.widget.close()

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -56,9 +56,6 @@ class WWTDataViewer(DataViewer):
 
         self._update_wwt_client(force=True)
 
-        if hasattr(self._wwt_client, 'save_as_html_bundle'):
-            self.subtools['save'].append('wwt:save_html')
-
     def closeEvent(self, event):
         self._wwt_client.widget.close()
         return super(WWTDataViewer, self).closeEvent(event)

--- a/glue_wwt/viewer/tools.py
+++ b/glue_wwt/viewer/tools.py
@@ -8,12 +8,12 @@ from glue.config import viewer_tool
 
 
 @viewer_tool
-class SaveTool(Tool):
+class SaveImageTool(Tool):
 
     icon = 'glue_filesave'
-    tool_id = 'wwt:save'
-    action_text = 'Save the view to a file'
-    tool_tip = 'Save the view to a file'
+    tool_id = 'wwt:save_image'
+    action_text = 'Save the view to an image'
+    tool_tip = 'Save the view to an image'
 
     def activate(self):
 
@@ -28,3 +28,25 @@ class SaveTool(Tool):
             return
 
         self.viewer._wwt_client.render(filename)
+
+@viewer_tool
+class SaveHtmlTool(Tool):
+    
+    icon = 'glue_filesave'
+    tool_id = 'wwt:save_html'
+    action_text = 'Save the view to an interactive figure'
+    tool_tip = 'Save the view to an interactive figure'
+
+    def activate(self):
+
+        filename, _ = compat.getsavefilename(caption='Save File',
+                                             filters='ZIP Files (*.zip);;',
+                                             selectedfilter='ZIP Files (*.zip);;')
+
+        # This indicates that the user cancelled
+        if not filename:
+            return
+
+        self.viewer._wwt_client.save_as_html_bundle(filename)
+
+    


### PR DESCRIPTION
Addresses #46 by using the pywwt interactive figure work (WorldWideTelescope/pywwt#215). This PR adds the option to save the current view to a zip file with an HTML page and supporting script and data files.