### PR TITLE
Fix altUnit to work correctly on Windows WWT client

### DIFF
--- a/glue_wwt/viewer/tools.py
+++ b/glue_wwt/viewer/tools.py
@@ -100,5 +100,15 @@ class SaveTourTool(Tool):
         if not tourxml:
             raise Exception("Failed to save tour")
 
+        # Patch the altUnit so that it is correct for the Windows client (since
+        # the web client currently has other bugs with relation to loading tours).
+        # https://github.com/WorldWideTelescope/wwt-web-client/issues/248
+        for unit_int in range(1, 11):
+            altunit_str = 'AltUnit="{0}"'.format(unit_int)
+            if altunit_str in tourxml:
+                altunit_str_new = 'AltUnit="{0}"'.format(unit_int - 1)
+                print('Changing {0} to {1} in {2}'.format(altunit_str, altunit_str_new, filename))
+                tourxml = tourxml.replace(altunit_str, altunit_str_new)
+
         with io.open(filename, 'w', newline='') as f:
             f.write(tourxml)


### PR DESCRIPTION
Currently altUnit is inconsistent in the web client and the Windows client:

https://github.com/WorldWideTelescope/wwt-web-client/issues/248

Since there other bugs that mean the tour file can't load properly in the web client anyway, we should fix altUnit so that it is correct in the Windows client.