### PR TITLE
Only apply longitude shifting conditionally

### DIFF
--- a/glue_wwt/viewer/table_layer.py
+++ b/glue_wwt/viewer/table_layer.py
@@ -23,6 +23,12 @@ import pywwt
 from distutils.version import LooseVersion
 PYWWT_LT_06 = LooseVersion(pywwt.__version__) < '0.6'
 
+# 0.13 is the first version that uses the WWT research app as the JS backend
+PYWWT_GE_013 = LooseVersion(pywwt.__version__) >= '0.13'
+
+# 0.9 is the first version that grabs the SDK from the WWT CDN
+PYWWT_LT_09 = LooseVersion(pywwt.__version__) < '0.9'
+
 
 __all__ = ['WWTTableLayerArtist']
 
@@ -264,16 +270,26 @@ class WWTTableLayerArtist(LayerArtist):
                 lon = coord.spherical.lon.degree
                 lat = coord.spherical.lat.degree
 
-            # For some reason in 3D mode, when the frame is Sky, we need to
-            # shift the longitudes by 180 degrees. However we also make sure
-            # we send the original version since this might be needed e.g. when
-            # exporting tours.
-            if self._viewer_state.mode in MODES_3D:
-                lon_orig = lon.copy()
-                lon = lon + 180
-                lon[lon > 360] -= 360
-            else:
-                lon_orig = None
+            # Previously, there was an error in the WWT WebGL engine which caused
+            # longitude values to be shifted by 180 degrees in 3d mode.
+            # See https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/34
+            # This was fixed in @wwtelescope/engine 7.14.5
+            # However, the WWT research app (which is the JS backend
+            # for pywwt >= 0.13), is not yet using the new engine
+            # so we need to keep this fix in place
+            # 0.9 <= pywwt <= 0.12 grabs the v7 engine from the WWT CDN
+            # so does not need the fix
+            # but pre-0.9 has its own internal wwtsdk.js (hosted on GitHub)
+            # and so does
+            need_longitude_fix = PYWWT_GE_013 or PYWWT_LT_09
+
+            if need_longitude_fix:
+                if self._viewer_state.mode in MODES_3D:
+                    lon_orig = lon.copy()
+                    lon = lon + 180
+                    lon[lon > 360] -= 360
+                else:
+                    lon_orig = None
 
             # FIXME: kpc isn't yet a valid unit in WWT/PyWWT:
             # https://github.com/WorldWideTelescope/wwt-web-client/pull/197
@@ -301,8 +317,9 @@ class WWTTableLayerArtist(LayerArtist):
                 tab['cmap'] = cmap_values
                 data_kwargs['cmap_att'] = 'cmap'
 
-            if lon_orig is not None:
-                tab['lon_orig'] = lon_orig * u.degree
+            if need_longitude_fix:
+                if lon_orig is not None:
+                    tab['lon_orig'] = lon_orig * u.degree
 
             self.wwt_layer = self.wwt_client.layers.add_table_layer(tab, frame=ref_frame,
                                                                     lon_att='lon', lat_att='lat',


### PR DESCRIPTION
This PR aims to update glue-wwt to account for the changes to the WWT WebGL engine in https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/166 (for the original issue describing the problem, see https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/34). glue-wwt had been shifting the longitudes of layers in 3D modes by 180 degrees to account for this bug. With the WWT engine update, this is now only sometimes necessary, and this PR adds appropriate conditional logic.

The reason for the conditional nature of this fix is based on the relationship between pywwt and the WebGL engine. There are three distinct cases across the pywwt timeline:

* `0.6 <= pywwt <= 0.8`: pywwt obtains the WWT engine from its own private copy hosted on the pywwt GitHub page. It doesn't seem that this file gets updated any longer (it's missing the updates pertaining to the recent fix). Thus, the glue-wwt longitude fix is still necessary to perform.
* `0.9 <= pywwt <= 0.12`: pywwt obtains the engine from the WWT CDN. In particular, all of these versions are grabbing https://web.wwtassets.org/engine/7/wwtsdk.js. Since the newest version of the engine is 7.14.5, the engine used by these versions contains the longitude update, and it is not necessary to implement on the glue-wwt side.
* `pywwt >= 0.13`: pywwt uses the WWT research app as the JS backend (in particular, all releases up to the current 0.14.0 use research app v0.7.1). This should be tied to a particular release of the engine, meaning that the longitude change won't be present. Thus, the glue-wwt fix is still necessary.

glue-wwt requires pywwt >= 0.6, so I don't think we need to worry about older versions. Once the version of the research app in (a future version of) pywwt includes the engine fix, we again won't need to make the longitude adjustment in glue-wwt. I'll make that change when we get there.

I'd appreciate any thoughts from @pkgw about whether there could be anything else worth considering here.