### PR TITLE
Switch CI from Azure to GitHub actions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,0 +1,34 @@
+name: CI Tests
+
+on:
+  push:
+  pull_request:
+  # schedule:
+  #   # run every Monday at 6am UTC
+  #   - cron: '0 6 * * 1'
+
+jobs:
+  ci-tests:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      libraries:
+        apt:
+          - libxkbcommon-x11-0
+          - libxcb-icccm4
+          - libxcb-image0
+          - libxcb-keysyms1
+          - libxcb-randr0
+          - libxcb-render-util0
+          - libxcb-xfixes0
+          - libxcb-xinerama0
+      coverage: codecov
+      envs: |
+        # Code style
+        - linux: style
+        # Standard tests
+        - linux: py36-test
+        - linux: py38-test
+        - macos: py36-test
+        - macos: py310-test
+        - windows: py36-test
+        - windows: py39-test


### PR DESCRIPTION
Transition using the reusable workflows from https://github.com/OpenAstronomy/github-actions-workflows