### PR TITLE
Fix incorrect attribute reference

### DIFF
--- a/glue_wwt/viewer/table_layer.py
+++ b/glue_wwt/viewer/table_layer.py
@@ -224,7 +224,7 @@ class WWTTableLayerArtist(LayerArtist):
             try:
                 lat = self.layer[self._viewer_state.lat_att]
             except IncompatibleAttribute:
-                self.disable_invalid_attributes(self._viewer_state.dec_att)
+                self.disable_invalid_attributes(self._viewer_state.lat_att)
                 return
 
             if self._viewer_state.alt_att is not None:


### PR DESCRIPTION
This PR corrects a reference to `self._viewer_state.dec_att` (which doesn't exist) to `self._viewer_state.lat_att` in the table layer's `_update_presentation` method. This code path is reached when adding a layer to the viewer whose latitude attribute is incompatible with the current viewer settings.