### PR TITLE
Image layer controls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.6 (unreleased)
+----------------
+
+- Added setting controls for image layers. [#88]
+
 0.5 (2020-11-30)
 ----------------
 

--- a/glue_wwt/viewer/image_layer.py
+++ b/glue_wwt/viewer/image_layer.py
@@ -14,7 +14,7 @@ from echo import (CallbackProperty,
                   SelectionCallbackProperty,
                   keep_in_sync)
 
-from pywwt.layers import VALID_STRETCHES
+from pywwt.layers import VALID_COLORMAPS, VALID_STRETCHES
 
 
 __all__ = ['WWTImageLayerArtist']
@@ -37,14 +37,19 @@ class WWTImageLayerState(LayerState):
         default_index=0,
         choices=VALID_STRETCHES
     )
+    cmap = SelectionCallbackProperty(
+        default_index=0,
+        choices=VALID_COLORMAPS
+    )
 
     def __init__(self, layer=None, **kwargs):
         super(WWTImageLayerState, self).__init__(layer=layer)
 
+        self.color = self.layer.style.color
+        self.alpha = self.layer.style.alpha
+
         self._sync_color = keep_in_sync(self, 'color', self.layer.style, 'color')
         self._sync_alpha = keep_in_sync(self, 'alpha', self.layer.style, 'alpha')
-
-        self.color = self.layer.style.color
 
         self.img_data_att_helper = ComponentIDComboHelper(self, 'img_data_att',
                                                           numeric=True,
@@ -141,6 +146,10 @@ class WWTImageLayerArtist(LayerArtist):
         if force or 'vmax' in changed:
             if self.state.vmax is not None:
                 self.wwt_layer.vmax = self.state.vmax
+
+        if force or 'cmap' in changed:
+            if self.state.cmap is not None:
+                self.wwt_layer.cmap = self.state.cmap
 
         self.enable()
 

--- a/glue_wwt/viewer/image_style_editor.py
+++ b/glue_wwt/viewer/image_style_editor.py
@@ -4,10 +4,13 @@ import os
 
 from qtpy import QtWidgets
 
+from echo.qt import autoconnect_callbacks_to_qt
 from glue.utils.qt import load_ui
 
 
 class WWTImageStyleEditor(QtWidgets.QWidget):
-    def __init__(self, layer_artist):
+    def __init__(self, layer):
         super(WWTImageStyleEditor, self).__init__()
         self.ui = load_ui('image_style_editor.ui', self, directory=os.path.dirname(__file__))
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections = autoconnect_callbacks_to_qt(layer.state, self.ui, connect_kwargs)

--- a/glue_wwt/viewer/image_style_editor.ui
+++ b/glue_wwt/viewer/image_style_editor.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>200</width>
-    <height>202</height>
+    <width>290</width>
+    <height>185</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -26,45 +26,62 @@
    <property name="bottomMargin">
     <number>3</number>
    </property>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Image styling unimplemented!</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_alpha">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer_3">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_vmin">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmin&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_stretch">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;stretch&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="combosel_cmap"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="valuetext_vmax"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSlider" name="value_alpha">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_cmap">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;colormap&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_vmax">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmax&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="combosel_stretch"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="valuetext_vmin"/>
+   </item>
+   <item row="5" column="1">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/glue_wwt/viewer/image_style_editor.ui
+++ b/glue_wwt/viewer/image_style_editor.ui
@@ -26,17 +26,16 @@
    <property name="bottomMargin">
     <number>3</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_alpha">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="valuetext_vmin"/>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_vmin">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_cmap">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmin&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;colormap&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -45,40 +44,10 @@
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;stretch&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="combosel_cmap"/>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="valuetext_vmax"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="QSlider" name="value_alpha">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_cmap">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;colormap&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_vmax">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmax&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="combosel_stretch"/>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="valuetext_vmin"/>
    </item>
    <item row="5" column="1">
     <spacer name="verticalSpacer">
@@ -92,6 +61,52 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_alpha">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLabel" name="label_vmax">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmax&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_vmin">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;vmin&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLineEdit" name="valuetext_vmax"/>
+   </item>
+   <item row="2" column="1" colspan="3">
+    <widget class="QSlider" name="value_alpha">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_stretch"/>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_cmap"/>
    </item>
   </layout>
  </widget>

--- a/glue_wwt/viewer/jupyter_viewer.py
+++ b/glue_wwt/viewer/jupyter_viewer.py
@@ -54,6 +54,7 @@ class JupyterImageLayerOptions(VBox):
         self.alpha = FloatSlider(description='alpha', min=0, max=1, value=self.state.alpha, step=0.01)
         link((self.state, 'alpha'), (self.alpha, 'value'))
 
+        self.cmap = LinkedDropdown(self.state, 'cmap', 'Colormap')
         self.stretch = LinkedDropdown(self.state, 'stretch', 'Stretch')
 
         self.vmin = FloatText(description='Min Val')
@@ -62,7 +63,7 @@ class JupyterImageLayerOptions(VBox):
         link((self.state, 'vmin'), (self.vmin, 'value'), lambda value: value or 0)
         link((self.state, 'vmax'), (self.vmax, 'value'), lambda value: value or 1)
 
-        super().__init__([self.data_att, self.alpha, self.stretch, self.lims])
+        super().__init__([self.data_att, self.alpha, self.cmap, self.stretch, self.lims])
 
 
 class JupyterTableLayerOptions(VBox):


### PR DESCRIPTION
This PR implements the functionality that was discussed at this morning's glue meeting - adding controls for image layer settings. See the image below for a visual depiction of the layer options widget. Additionally, a `cmap` attribute is added to the image layer class, which is wired up to the `cmap` attribute of the underlying WWT layer.

![image_layer_editor](https://user-images.githubusercontent.com/14281631/176777183-5cfa0692-7554-45ac-80e9-18b30770cb60.png)

The code changes here are relatively minimal since most of the wiring between the glue and pywwt layers is already in place; they just needed to be exposed to the Qt application. @pkgw, if you have any thoughts on any changes/other things to add here, that would be great.