### PR TITLE
Create table layers as non-selectable in pywwt

### DIFF
--- a/glue_wwt/viewer/table_layer.py
+++ b/glue_wwt/viewer/table_layer.py
@@ -20,6 +20,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
 import pywwt
+from pywwt.layers import TableLayer
 from distutils.version import LooseVersion
 PYWWT_LT_06 = LooseVersion(pywwt.__version__) < '0.6'
 
@@ -324,6 +325,9 @@ class WWTTableLayerArtist(LayerArtist):
             if need_longitude_fix:
                 if lon_orig is not None:
                     tab['lon_orig'] = lon_orig * u.degree
+
+            if 'selectable' in TableLayer.class_trait_names():
+                data_kwargs['selectable'] = False
 
             self.wwt_layer = self.wwt_client.layers.add_table_layer(tab, frame=ref_frame,
                                                                     lon_att='lon', lat_att='lat',


### PR DESCRIPTION
This PR updates the glue-wwt table layer to be aware of the changes in https://github.com/WorldWideTelescope/pywwt/pull/334. Recent versions of pywwt have the ability to allow the user to select sources from a catalog via a mouse click, and bring that information into Python.  Since we aren't using this in glue-wwt, we don't want the cursor change that accompanies mousing over a point, and so this PR creates the layer with `selectable=False` when the option exists. We should also see a performance improvement when there are a lot of points displayed, since the pywwt JS does some calculations to determine when the cursor is over a selectable point. Note that this PR doesn't prevent us from using selectability in the future in e.g. some selection tool - the layer's `selectable` attribute can be modified after creation.