### PR TITLE
Truncate SkyCoord exception if too long

### DIFF
--- a/glue_wwt/viewer/table_layer.py
+++ b/glue_wwt/viewer/table_layer.py
@@ -268,7 +268,12 @@ class WWTTableLayerArtist(LayerArtist):
                     coord = SkyCoord(lon, lat, unit=u.deg,
                                      frame=self._viewer_state.frame.lower()).icrs
                 except Exception as exc:
-                    self.disable(str(exc))
+                    # Truncate the exception string if it's too long
+                    disable_msg = str(exc)
+                    max_length = 300
+                    if len(disable_msg) > max_length:
+                        disable_msg = disable_msg[:max_length] + "..."
+                    self.disable(disable_msg)
                     return
 
                 lon = coord.spherical.lon.degree

--- a/glue_wwt/viewer/table_layer.py
+++ b/glue_wwt/viewer/table_layer.py
@@ -19,6 +19,8 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
+from numpy import size
+
 import pywwt
 from pywwt.layers import TableLayer
 from distutils.version import LooseVersion
@@ -267,12 +269,12 @@ class WWTTableLayerArtist(LayerArtist):
                 try:
                     coord = SkyCoord(lon, lat, unit=u.deg,
                                      frame=self._viewer_state.frame.lower()).icrs
-                except Exception as exc:
-                    # Truncate the exception string if it's too long
-                    disable_msg = str(exc)
-                    max_length = 300
-                    if len(disable_msg) > max_length:
-                        disable_msg = disable_msg[:max_length] + "..."
+                except Exception:
+                    if size(lat) < 5:
+                        angle_info = f"{lat}"
+                    else:
+                        angle_info = f"{lat.min()} deg <= angle <= {lat.max()} deg"
+                    disable_msg = f"Latitude angle(s) must be within -90 deg <= angle <= 90 deg, got {angle_info}"
                     self.disable(disable_msg)
                     return
 

--- a/glue_wwt/viewer/tests/test_utils.py
+++ b/glue_wwt/viewer/tests/test_utils.py
@@ -30,3 +30,7 @@ def test_center_fov_non_finite():
     assert_allclose(lon_c, 3)
     assert_allclose(lat_c, 2)
     assert_allclose(fov, 1)
+
+
+def create_disabled_message(reason):
+    return "Cannot visualize this layer: %s" % reason


### PR DESCRIPTION
This PR looks to solve a problem where the exception message can be very long when one of the latitude angles is not with [-90°, 90°]. This error message comes from astropy (see https://github.com/astropy/astropy/issues/13994), so this PR just truncates the message if it's longer than 300 characters (adding a ... to the end so the user knows that this isn't the full exception).