### PR TITLE
Save and restore camera parameters

### DIFF
--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from glue.core.coordinates import WCSCoordinates
+from pywwt import ViewerNotAvailableError
 
 from .image_layer import WWTImageLayerArtist
 from .table_layer import WWTTableLayerArtist
@@ -97,13 +98,16 @@ class WWTDataViewerBase(object):
 
     def __gluestate__(self, context):
         state = super(WWTDataViewerBase, self).__gluestate__(context)
-
-        center = self._wwt.get_center()
-        state["camera"] = {
-            "ra": center.ra.deg,
-            "dec": center.dec.deg,
-            "fov": self._wwt.get_fov().value
-        }
+        try:
+            center = self._wwt.get_center()
+            camera = {
+                "ra": center.ra.deg,
+                "dec": center.dec.deg,
+                "fov": self._wwt.get_fov().value
+            }
+            state["camera"] = camera
+        except ViewerNotAvailableError:
+            pass
         return state
 
     @classmethod

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -106,6 +106,8 @@ class WWTDataViewerBase(object):
                 "dec": center.dec.deg,
                 "fov": self._wwt.get_fov().value
             }
+            if hasattr(self._wwt, 'get_roll'):
+                camera["roll"] = self._wwt.get_roll().value
             state["camera"] = camera
         except ViewerNotAvailableError:
             logger.error("Unable to export camera parameters as WWT viewer is not responding.")
@@ -119,5 +121,9 @@ class WWTDataViewerBase(object):
             ra = camera.get("ra", 0)
             dec = camera.get("dec", 0)
             fov = camera.get("fov", 60)
-            viewer._wwt.center_on_coordinates(SkyCoord(ra, dec, unit=u.deg), fov=fov * u.deg, instant=True)
+            roll = camera.get("roll", None)
+            camera_kwargs = dict(fov=fov * u.deg, instant=True)
+            if hasattr(viewer._wwt, 'get_roll') and roll is not None:
+                camera_kwargs["roll"] = roll * u.deg
+            viewer._wwt.center_on_coordinates(SkyCoord(ra, dec, unit=u.deg), **camera_kwargs)
         return viewer

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -27,7 +27,6 @@ class WWTDataViewerBase(object):
     }
 
     _UPDATE_SETTINGS = [
-        "foreground", "background", "foreground_opacity", "galactic",
         "equatorial_grid", "equatorial_grid_color", "equatorial_text",
         "ecliptic_grid", "ecliptic_grid_color", "ecliptic_text",
         "alt_az_grid", "alt_az_grid_color", "alt_az_text",
@@ -38,6 +37,8 @@ class WWTDataViewerBase(object):
         "ecliptic", "ecliptic_color", "precession_chart",
         "precession_chart_color"
     ]
+
+    _IMAGERY_UPDATE_SETTINGS = ["foreground", "background", "foreground_opacity", "galactic"]
 
     def __init__(self):
         self._initialize_wwt()
@@ -57,6 +58,7 @@ class WWTDataViewerBase(object):
             self._wwt.solar_system.cosmos = self.state.mode == 'Universe'
             # Only show local stars when not in Universe or Milky Way mode
             self._wwt.solar_system.stars = self.state.mode not in ['Universe', 'Milky Way']
+            force = True
 
         if force or 'constellation_boundaries' in kwargs:
             self._wwt.constellation_boundaries = self.state.constellation_boundaries != 'None'
@@ -66,6 +68,12 @@ class WWTDataViewerBase(object):
             if force or setting in kwargs:
                 wwt_attr = self._GLUE_TO_WWT_ATTR_MAP.get(setting, setting)
                 setattr(self._wwt, wwt_attr, getattr(self.state, setting, None))
+        
+        show_imagery = self.state.mode == 'Sky'
+        if show_imagery:
+            for setting in self._IMAGERY_UPDATE_SETTINGS:
+                if force or setting in kwargs:
+                    setattr(self._wwt, setting, getattr(self.state, setting, None))
 
     def get_layer_artist(self, cls, **kwargs):
         "In this package, we must override to append the wwt_client argument."
@@ -108,4 +116,3 @@ class WWTDataViewerBase(object):
             fov = camera.get("fov", 60)
             viewer._wwt.center_on_coordinates(SkyCoord(ra, dec, unit=u.deg), fov=fov * u.deg, instant=True)
         return viewer
-

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from glue.core.coordinates import WCSCoordinates
+from glue.logger import logger
 from pywwt import ViewerNotAvailableError
 
 from .image_layer import WWTImageLayerArtist
@@ -107,7 +108,7 @@ class WWTDataViewerBase(object):
             }
             state["camera"] = camera
         except ViewerNotAvailableError:
-            pass
+            logger.error("Unable to export camera parameters as WWT viewer is not responding.")
         return state
 
     @classmethod

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -70,7 +70,7 @@ class WWTDataViewerBase(object):
             if force or setting in kwargs:
                 wwt_attr = self._GLUE_TO_WWT_ATTR_MAP.get(setting, setting)
                 setattr(self._wwt, wwt_attr, getattr(self.state, setting, None))
-        
+
         show_imagery = self.state.mode == 'Sky'
         if show_imagery:
             for setting in self._IMAGERY_UPDATE_SETTINGS:


### PR DESCRIPTION
It was mentioned at glue-con that the WWT viewer doesn't save its camera information (RA and dec position, FOV, roll angle) to a session file. This PR aims to fix that issue (with the exception of the viewer's roll angle, which isn't yet exposed to the pywwt widgets - I'll change that upstream and then add that here in a future PR once it's available).

I suspect the reason that this wasn't implemented before now is because this information isn't stored in either of the relevant glue objects (either the viewer state or the viewer itself). The camera position is stored and updated inside of the WWT widget object of the viewer (the `_wwt` member value). Since the viewer state doesn't have access to the WWT widget, the implementation here stores/reads the camera information in the glue state methods for the viewer itself. For restoring state, this PR accounts for the fact that changing the background image (which here is always a sky imageset) will cause the WWT viewer's mode to match that of the imageset, so we need to avoid that when setting the mode to something other than Sky.

Note that this PR does not fix the (pre-existing) issue where the sky mode does not respect previously set background/foreground imagesets when changing into that mode, making the UI and viewer out of sync. While I've identified the cause of that, it's unrelated and I think may be better helped with an upstream change.