### PR TITLE
Expose grid and constellation settings

### DIFF
--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -60,7 +60,6 @@ class WWTDataViewerBase(object):
                 wwt_attr = self._GLUE_TO_WWT_ATTR_MAP.get(setting, setting)
                 setattr(self._wwt, wwt_attr, getattr(self.state, setting, None))
 
-
     def get_layer_artist(self, cls, **kwargs):
         "In this package, we must override to append the wwt_client argument."
         return cls(self.state, wwt_client=self._wwt, **kwargs)

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -19,7 +19,9 @@ class WWTDataViewerBase(object):
 
     _GLUE_TO_WWT_ATTR_MAP = {
         "galactic": "galactic_mode",
-        "equatorial_grid": "grid"
+        "equatorial_grid": "grid",
+        "equatorial_grid_color": "grid_color",
+        "equatorial_text": "grid_text"
     }
 
     _UPDATE_SETTINGS = [
@@ -28,10 +30,9 @@ class WWTDataViewerBase(object):
         "ecliptic_grid", "ecliptic_grid_color", "ecliptic_text",
         "alt_az_grid", "alt_az_grid_color", "alt_az_text",
         "galactic_grid", "galactic_grid_color", "galactic_text",
-        "constellation_boundaries", "constellation_boundary_color",
-        "constellation_selection", "constellation_selection_color",
+        "constellation_boundary_color", "constellation_selection_color",
         "constellation_figures", "constellation_figure_color",
-        "constellation_pictures", "crosshairs", "crosshairs_color",
+        "constellation_labels", "constellation_pictures", "crosshairs",
         "ecliptic", "ecliptic_color", "precession_chart",
         "precession_chart_color"
     ]
@@ -54,6 +55,10 @@ class WWTDataViewerBase(object):
             self._wwt.solar_system.cosmos = self.state.mode == 'Universe'
             # Only show local stars when not in Universe or Milky Way mode
             self._wwt.solar_system.stars = self.state.mode not in ['Universe', 'Milky Way']
+
+        if force or 'constellation_boundaries' in kwargs:
+            self._wwt.constellation_boundaries = self.state.constellation_boundaries != 'None'
+            self._wwt.constellation_selection = self.state.constellation_boundaries == 'Selection only'
 
         for setting in self._UPDATE_SETTINGS:
             if force or setting in kwargs:

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -17,6 +17,25 @@ class WWTDataViewerBase(object):
 
     _state_cls = WWTDataViewerState
 
+    _GLUE_TO_WWT_ATTR_MAP = {
+        "galactic": "galactic_mode",
+        "equatorial_grid": "grid"
+    }
+
+    _UPDATE_SETTINGS = [
+        "foreground", "background", "foreground_opacity", "galactic",
+        "equatorial_grid", "equatorial_grid_color", "equatorial_text",
+        "ecliptic_grid", "ecliptic_grid_color", "ecliptic_text",
+        "alt_az_grid", "alt_az_grid_color", "alt_az_text",
+        "galactic_grid", "galactic_grid_color", "galactic_text",
+        "constellation_boundaries", "constellation_boundary_color",
+        "constellation_selection", "constellation_selection_color",
+        "constellation_figures", "constellation_figure_color",
+        "constellation_pictures", "crosshairs", "crosshairs_color",
+        "ecliptic", "ecliptic_color", "precession_chart",
+        "precession_chart_color"
+    ]
+
     def __init__(self):
         self._initialize_wwt()
         self._wwt.actual_planet_scale = True
@@ -36,35 +55,11 @@ class WWTDataViewerBase(object):
             # Only show local stars when not in Universe or Milky Way mode
             self._wwt.solar_system.stars = self.state.mode not in ['Universe', 'Milky Way']
 
-        if force or 'foreground' in kwargs:
-            self._wwt.foreground = self.state.foreground
+        for setting in self._UPDATE_SETTINGS:
+            if force or setting in kwargs:
+                wwt_attr = self._GLUE_TO_WWT_ATTR_MAP.get(setting, setting)
+                setattr(self._wwt, wwt_attr, getattr(self.state, setting, None))
 
-        if force or 'background' in kwargs:
-            self._wwt.background = self.state.background
-
-        if force or 'foreground_opacity' in kwargs:
-            self._wwt.foreground_opacity = self.state.foreground_opacity
-
-        if force or 'galactic' in kwargs:
-            self._wwt.galactic_mode = self.state.galactic
-
-        if force or 'constellation_boundaries' in kwargs:
-            self._wwt.constellation_boundaries = self.state.constellation_boundaries
-
-        if force or 'constellation_figures' in kwargs:
-            self._wwt.constellation_figures = self.state.constellation_figures
-
-        if force or 'equatorial_grid' in kwargs:
-            self._wwt.grid = self.state.equatorial_grid
-
-        if force or 'ecliptic_grid' in kwargs:
-            self._wwt.ecliptic_grid = self.state.ecliptic_grid
-
-        if force or 'alt_az_grid' in kwargs:
-            self._wwt.alt_az_grid = self.state.alt_az_grid
-
-        if force or 'galactic_grid' in kwargs:
-            self._wwt.galactic_grid = self.state.galactic_grid
 
     def get_layer_artist(self, cls, **kwargs):
         "In this package, we must override to append the wwt_client argument."

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -48,6 +48,16 @@ class WWTDataViewerBase(object):
         if force or 'galactic' in kwargs:
             self._wwt.galactic_mode = self.state.galactic
 
+        if force or 'constellation_boundaries' in kwargs:
+            self._wwt.constellation_boundaries = self.state.constellation_boundaries
+
+        if force or 'constellation_figures' in kwargs:
+            self._wwt.constellation_figures = self.state.constellation_figures
+
+        if force or 'grid' in kwargs or 'galactic' in kwargs:
+            self._wwt.galactic_grid = self.state.grid and self.state.galactic
+            self._wwt.grid = self.state.grid and not self.state.galactic
+
     def get_layer_artist(self, cls, **kwargs):
         "In this package, we must override to append the wwt_client argument."
         return cls(self.state, wwt_client=self._wwt, **kwargs)

--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -54,9 +54,17 @@ class WWTDataViewerBase(object):
         if force or 'constellation_figures' in kwargs:
             self._wwt.constellation_figures = self.state.constellation_figures
 
-        if force or 'grid' in kwargs or 'galactic' in kwargs:
-            self._wwt.galactic_grid = self.state.grid and self.state.galactic
-            self._wwt.grid = self.state.grid and not self.state.galactic
+        if force or 'equatorial_grid' in kwargs:
+            self._wwt.grid = self.state.equatorial_grid
+
+        if force or 'ecliptic_grid' in kwargs:
+            self._wwt.ecliptic_grid = self.state.ecliptic_grid
+
+        if force or 'alt_az_grid' in kwargs:
+            self._wwt.alt_az_grid = self.state.alt_az_grid
+
+        if force or 'galactic_grid' in kwargs:
+            self._wwt.galactic_grid = self.state.galactic_grid
 
     def get_layer_artist(self, cls, **kwargs):
         "In this package, we must override to append the wwt_client argument."

--- a/glue_wwt/viewer/jupyter_viewer.py
+++ b/glue_wwt/viewer/jupyter_viewer.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+from glue.utils import color2hex
 from glue_jupyter.view import IPyWidgetView
 from glue_jupyter.link import link, dlink
 from glue_jupyter.widgets import LinkedDropdown, Color, Size
 
 from pywwt.jupyter import WWTJupyterWidget
 
-from ipywidgets import HBox, Tab, VBox, FloatSlider, FloatText
+from ipywidgets import Accordion, Checkbox, ColorPicker, GridBox, HBox, Label, Layout, Tab, VBox, FloatSlider, FloatText
 
 from .data_viewer import WWTDataViewerBase
 from .image_layer import WWTImageLayerArtist
@@ -15,6 +16,8 @@ from .table_layer import WWTTableLayerArtist
 
 class JupterViewerOptions(VBox):
     def __init__(self, viewer_state, available_layers):
+
+        self.fit_content_layout = Layout(width="fit-content")
 
         self.state = viewer_state
 
@@ -39,8 +42,125 @@ class JupterViewerOptions(VBox):
         dlink((self.state, 'mode'), (self.widget_allskyimg.layout, 'display'),
               lambda value: '' if value == 'Sky' else 'none')
 
-        super().__init__([self.widget_mode, self.widget_frame, self.widget_ra,
-                          self.widget_dec, self.alt_opts, self.widget_allskyimg])
+        self.widget_crosshairs = self.linked_checkbox('crosshairs', description="Show crosshairs")
+        self.widget_galactic_plane_mode = self.linked_checkbox('galactic', description="Galactic Plane mode")
+
+        self.general_settings = VBox(children=[self.widget_mode, self.widget_frame, self.widget_ra,
+                                               self.widget_dec, self.alt_opts, self.widget_allskyimg,
+                                               self.widget_crosshairs, self.widget_galactic_plane_mode])
+
+        self.widget_alt_az_grid = self.linked_checkbox('alt_az_grid', description="Alt/Az")
+        self.widget_alt_az_text = self.linked_checkbox('alt_az_text', description="Text")
+        self.set_enabled_from_checkbox(self.widget_alt_az_text, self.widget_alt_az_grid)
+        self.widget_alt_az_grid_color = self.linked_color_picker('alt_az_grid_color')
+        self.set_enabled_from_checkbox(self.widget_alt_az_grid_color, self.widget_alt_az_grid)
+
+        self.widget_ecliptic_grid = self.linked_checkbox('ecliptic_grid', description="Ecliptic")
+        self.widget_ecliptic_text = self.linked_checkbox('ecliptic_text', description="Text")
+        self.set_enabled_from_checkbox(self.widget_ecliptic_text, self.widget_ecliptic_grid)
+        self.widget_ecliptic_grid_color = self.linked_color_picker('ecliptic_grid_color')
+        self.set_enabled_from_checkbox(self.widget_ecliptic_grid_color, self.widget_ecliptic_grid)
+
+        self.widget_equatorial_grid = self.linked_checkbox('equatorial_grid', "Equatorial")
+        self.widget_equatorial_text = self.linked_checkbox('equatorial_text', "Text")
+        self.set_enabled_from_checkbox(self.widget_equatorial_text, self.widget_equatorial_grid)
+        self.widget_equatorial_grid_color = self.linked_color_picker('equatorial_grid_color')
+        self.set_enabled_from_checkbox(self.widget_equatorial_grid_color, self.widget_equatorial_grid)
+
+        self.widget_galactic_grid = self.linked_checkbox('galactic_grid', description="Galactic")
+        self.widget_galactic_text = self.linked_checkbox('galactic_text', description="Text")
+        self.set_enabled_from_checkbox(self.widget_galactic_text, self.widget_galactic_grid)
+        self.widget_galactic_grid_color = self.linked_color_picker('galactic_grid_color')
+        self.set_enabled_from_checkbox(self.widget_galactic_grid_color, self.widget_galactic_grid)
+
+        self.grid_settings = GridBox(children=[self.widget_alt_az_grid, self.widget_alt_az_text,
+                                               self.widget_alt_az_grid_color, self.widget_ecliptic_grid,
+                                               self.widget_ecliptic_text, self.widget_ecliptic_grid_color,
+                                               self.widget_equatorial_grid, self.widget_equatorial_text,
+                                               self.widget_equatorial_grid_color, self.widget_galactic_grid,
+                                               self.widget_galactic_text, self.widget_galactic_grid_color],
+                                     layout=Layout(grid_template_columns="2fr 2fr 1fr", width="100%",
+                                                   grid_gap="2px 10px"))
+
+        self.widget_constellation_boundaries = LinkedDropdown(self.state, 'constellation_boundaries',
+                                                              label="Show boundaries")
+        self.widget_constellation_boundary_color = self.linked_color_picker('constellation_boundary_color',
+                                                                            description="Boundary")
+        dlink((self.widget_constellation_boundaries, 'value'), (self.widget_constellation_boundary_color, 'disabled'),
+              lambda value: value != "All")
+        self.widget_constellation_selection_color = self.linked_color_picker('constellation_selection_color',
+                                                                             description="Selection")
+        dlink((self.widget_constellation_boundaries, 'value'), (self.widget_constellation_selection_color, 'disabled'),
+              lambda value: value == "None")
+
+        self.widget_constellation_figures = self.linked_checkbox('constellation_figures', description="Figures")
+        self.widget_constellation_figure_color = self.linked_color_picker('constellation_figure_color',
+                                                                          description="Figure")
+        self.set_enabled_from_checkbox(self.widget_constellation_figure_color, self.widget_constellation_figures)
+        self.widget_constellation_labels = self.linked_checkbox('constellation_labels', description="Labels")
+        self.widget_constellation_pictures = self.linked_checkbox('constellation_pictures', description="Pictures")
+
+        constellations_hbox_layout = Layout(gap="10px", justify_content="space-between")
+        constellations_vbox_layout = Layout(height="fit-content", gap="2px", padding="5px", flex_direction="column")
+        self.constellation_checkboxes = HBox(children=[self.widget_constellation_pictures,
+                                                       self.widget_constellation_labels,
+                                                       self.widget_constellation_figures],
+                                             layout=constellations_hbox_layout)
+
+        self.constellation_colors = VBox(children=[self.widget_constellation_selection_color,
+                                                   self.widget_constellation_boundary_color,
+                                                   self.widget_constellation_figure_color],
+                                         layout=constellations_vbox_layout)
+
+        self.constellation_settings = VBox(children=[self.widget_constellation_boundaries,
+                                                     self.constellation_checkboxes,
+                                                     self.constellation_colors],
+                                           layout=constellations_vbox_layout)
+
+        self.widget_ecliptic_label = Label("Ecliptic:")
+        self.widget_ecliptic = self.linked_checkbox('ecliptic', description="Show")
+        self.widget_ecliptic_color = self.linked_color_picker('ecliptic_color')
+        self.set_enabled_from_checkbox(self.widget_ecliptic_color, self.widget_ecliptic)
+
+        self.widget_precession_chart_label = Label("Precession Chart:")
+        self.widget_precession_chart = self.linked_checkbox('precession_chart', description="Show")
+        self.widget_precession_chart_color = self.linked_color_picker('precession_chart_color')
+        self.set_enabled_from_checkbox(self.widget_precession_chart_color, self.widget_precession_chart)
+
+        self.other_settings = GridBox(children=[self.widget_ecliptic_label, self.widget_ecliptic,
+                                                self.widget_ecliptic_color, self.widget_precession_chart_label,
+                                                self.widget_precession_chart, self.widget_precession_chart_color],
+                                      layout=Layout(grid_template_columns="5fr 1fr 1fr", width="100%",
+                                                    grid_gap="2px 10px"))
+
+        self.settings = Accordion(children=[self.general_settings, self.grid_settings,
+                                            self.constellation_settings, self.other_settings],
+                                  layout=Layout(width="350px"))
+        self.settings.set_title(0, "General")
+        self.settings.set_title(1, "Grids")
+        self.settings.set_title(2, "Constellations")
+        self.settings.set_title(3, "Other")
+        self.settings.selected_index = 0
+
+        super().__init__([self.settings])
+
+    def linked_checkbox(self, attr, description=''):
+        widget = Checkbox(getattr(self.state, 'attr', False), description=description,
+                          indent=False, layout=self.fit_content_layout)
+        link((self.state, attr), (widget, 'value'))
+        return widget
+
+    def linked_color_picker(self, attr, description=''):
+        widget = ColorPicker(concise=True, layout=self.fit_content_layout, description=description)
+        link((self.state, attr), (widget, 'value'), color2hex)
+        return widget
+
+    @staticmethod
+    def opposite(value):
+        return not value
+
+    def set_enabled_from_checkbox(self, widget, checkbox):
+        dlink((checkbox, 'value'), (widget, 'disabled'), self.opposite)
 
 
 class JupyterImageLayerOptions(VBox):
@@ -97,7 +217,7 @@ class WWTJupyterViewer(WWTDataViewerBase, IPyWidgetView):
                                 self._layout_layer_options])
         self._layout_tab.set_title(0, "General")
         self._layout_tab.set_title(1, "Layers")
-        self._layout = HBox([self.figure_widget, self._layout_tab])
+        self._layout = HBox([self.figure_widget, self._layout_tab], layout=Layout(height="400px"))
 
     def _initialize_wwt(self):
         self._wwt = WWTJupyterWidget()

--- a/glue_wwt/viewer/jupyter_viewer.py
+++ b/glue_wwt/viewer/jupyter_viewer.py
@@ -83,7 +83,7 @@ class JupterViewerOptions(VBox):
                                                    grid_gap="2px 10px"))
 
         self.widget_constellation_boundaries = LinkedDropdown(self.state, 'constellation_boundaries',
-                                                              label="Show boundaries")
+                                                              label="Boundaries:")
         self.widget_constellation_boundary_color = self.linked_color_picker('constellation_boundary_color',
                                                                             description="Boundary")
         dlink((self.widget_constellation_boundaries, 'value'), (self.widget_constellation_boundary_color, 'disabled'),

--- a/glue_wwt/viewer/options_widget.py
+++ b/glue_wwt/viewer/options_widget.py
@@ -51,8 +51,12 @@ class WWTOptionPanel(QtWidgets.QWidget):
         self.ui.combosel_alt_unit.setVisible(show_alt)
 
         show_grid_constellations = self._viewer_state.mode == 'Sky'
-        self.ui.bool_grid.setVisible(show_grid_constellations)
+        self.ui.bool_equatorial_grid.setVisible(show_grid_constellations)
+        self.ui.bool_ecliptic_grid.setVisible(show_grid_constellations)
+        self.ui.bool_alt_az_grid.setVisible(show_grid_constellations)
+        self.ui.bool_galactic_grid.setVisible(show_grid_constellations)
         self.ui.label_constellation.setVisible(show_grid_constellations)
+        self.ui.label_grids.setVisible(show_grid_constellations)
         self.ui.bool_constellation_boundaries.setVisible(show_grid_constellations)
         self.ui.bool_constellation_figures.setVisible(show_grid_constellations)
 

--- a/glue_wwt/viewer/options_widget.py
+++ b/glue_wwt/viewer/options_widget.py
@@ -50,6 +50,12 @@ class WWTOptionPanel(QtWidgets.QWidget):
         self.ui.combosel_alt_att.setVisible(show_alt)
         self.ui.combosel_alt_unit.setVisible(show_alt)
 
+        show_grid_constellations = self._viewer_state.mode == 'Sky'
+        self.ui.bool_grid.setVisible(show_grid_constellations)
+        self.ui.label_constellation.setVisible(show_grid_constellations)
+        self.ui.bool_constellation_boundaries.setVisible(show_grid_constellations)
+        self.ui.bool_constellation_figures.setVisible(show_grid_constellations)
+
         if self._viewer_state.mode in MODES_BODIES:
             self.ui.label_lon_att.setText('Longitude')
             self.ui.label_lat_att.setText('Latitude')

--- a/glue_wwt/viewer/options_widget.py
+++ b/glue_wwt/viewer/options_widget.py
@@ -11,9 +11,14 @@ from .viewer_state import MODES_BODIES
 __all__ = ['WWTOptionPanel']
 
 
-def _set_enabled_from_checkbox(checkbox, dependent):
-    checkbox.toggled.connect(dependent.setEnabled)
-    dependent.setEnabled(checkbox.isChecked())
+def _set_enabled_from_checkbox(widget, checkbox):
+    checkbox.toggled.connect(widget.setEnabled)
+    widget.setEnabled(checkbox.isChecked())
+
+
+def _enabled_if_combosel_in(widget, combo, options):
+    combo.currentTextChanged.connect(lambda text: widget.setEnabled(text in options))
+    widget.setEnabled(combo.currentText() in options)
 
 
 class WWTOptionPanel(QtWidgets.QWidget):
@@ -37,27 +42,24 @@ class WWTOptionPanel(QtWidgets.QWidget):
         self._update_visible_options()
 
     def _setup_widget_dependencies(self):
-        _set_enabled_from_checkbox(self.ui.bool_alt_az_grid, self.ui.bool_alt_az_text)
-        _set_enabled_from_checkbox(self.ui.bool_alt_az_grid, self.ui.color_alt_az_grid_color)
-        _set_enabled_from_checkbox(self.ui.bool_ecliptic_grid, self.ui.bool_ecliptic_text)
-        _set_enabled_from_checkbox(self.ui.bool_ecliptic_grid, self.ui.color_ecliptic_grid_color)
-        _set_enabled_from_checkbox(self.ui.bool_equatorial_grid, self.ui.bool_equatorial_text)
-        _set_enabled_from_checkbox(self.ui.bool_equatorial_grid, self.ui.color_equatorial_grid_color)
-        _set_enabled_from_checkbox(self.ui.bool_galactic_grid, self.ui.bool_galactic_text)
-        _set_enabled_from_checkbox(self.ui.bool_galactic_grid, self.ui.color_galactic_grid_color)
-        _set_enabled_from_checkbox(self.ui.bool_constellation_figures, self.ui.color_constellation_figure_color)
-        _set_enabled_from_checkbox(self.ui.bool_ecliptic, self.ui.color_ecliptic_color)
-        _set_enabled_from_checkbox(self.ui.bool_precession_chart, self.ui.color_precession_chart_color)
+        _set_enabled_from_checkbox(self.ui.bool_alt_az_text, self.ui.bool_alt_az_grid)
+        _set_enabled_from_checkbox(self.ui.color_alt_az_grid_color, self.ui.bool_alt_az_grid)
+        _set_enabled_from_checkbox(self.ui.bool_ecliptic_text, self.ui.bool_ecliptic_grid)
+        _set_enabled_from_checkbox(self.ui.color_ecliptic_grid_color, self.ui.bool_ecliptic_grid)
+        _set_enabled_from_checkbox(self.ui.bool_equatorial_text, self.ui.bool_equatorial_grid)
+        _set_enabled_from_checkbox(self.ui.color_equatorial_grid_color, self.ui.bool_equatorial_grid)
+        _set_enabled_from_checkbox(self.ui.bool_galactic_text, self.ui.bool_galactic_grid)
+        _set_enabled_from_checkbox(self.ui.color_galactic_grid_color, self.ui.bool_galactic_grid)
+        _set_enabled_from_checkbox(self.ui.color_constellation_figure_color, self.ui.bool_constellation_figures)
+        _set_enabled_from_checkbox(self.ui.color_ecliptic_color, self.ui.bool_ecliptic)
+        _set_enabled_from_checkbox(self.ui.color_precession_chart_color, self.ui.bool_precession_chart)
 
-        def enable_if_in(text, options, widget):
-            widget.setEnabled(text in options)
-        self.ui.combosel_constellation_boundaries.currentTextChanged.connect(
-            lambda text: enable_if_in(text, ['All'], self.ui.color_constellation_boundary_color))
-        enable_if_in(self._viewer_state.constellation_boundaries, ['All'], self.ui.color_constellation_boundary_color)
-        self.ui.combosel_constellation_boundaries.currentTextChanged.connect(
-            lambda text: enable_if_in(text, ['All', 'Selection only'], self.ui.color_constellation_selection_color))
-        enable_if_in(self._viewer_state.constellation_boundaries, ['All', 'Selection only'], self.ui.color_constellation_selection_color)
-
+        _enabled_if_combosel_in(self.ui.color_constellation_boundary_color,
+                                self.ui.combosel_constellation_boundaries,
+                                ['All'])
+        _enabled_if_combosel_in(self.ui.color_constellation_selection_color,
+                                self.ui.combosel_constellation_boundaries,
+                                ['All', 'Selection only'])
 
     def _update_visible_options(self, *args, **kwargs):
 

--- a/glue_wwt/viewer/options_widget.py
+++ b/glue_wwt/viewer/options_widget.py
@@ -50,15 +50,9 @@ class WWTOptionPanel(QtWidgets.QWidget):
         self.ui.combosel_alt_att.setVisible(show_alt)
         self.ui.combosel_alt_unit.setVisible(show_alt)
 
-        show_grid_constellations = self._viewer_state.mode == 'Sky'
-        self.ui.bool_equatorial_grid.setVisible(show_grid_constellations)
-        self.ui.bool_ecliptic_grid.setVisible(show_grid_constellations)
-        self.ui.bool_alt_az_grid.setVisible(show_grid_constellations)
-        self.ui.bool_galactic_grid.setVisible(show_grid_constellations)
-        self.ui.label_constellation.setVisible(show_grid_constellations)
-        self.ui.label_grids.setVisible(show_grid_constellations)
-        self.ui.bool_constellation_boundaries.setVisible(show_grid_constellations)
-        self.ui.bool_constellation_figures.setVisible(show_grid_constellations)
+        show_grid_constellations = self._viewer_state.mode in ['Sky', 'Solar System', 'Milky Way', 'Universe']
+        for tab in range(1, self.ui.tab_widget.count()):
+            self.ui.tab_widget.setTabEnabled(tab, show_grid_constellations)
 
         if self._viewer_state.mode in MODES_BODIES:
             self.ui.label_lon_att.setText('Longitude')

--- a/glue_wwt/viewer/options_widget.py
+++ b/glue_wwt/viewer/options_widget.py
@@ -11,6 +11,11 @@ from .viewer_state import MODES_BODIES
 __all__ = ['WWTOptionPanel']
 
 
+def _set_enabled_from_checkbox(checkbox, dependent):
+    checkbox.toggled.connect(dependent.setEnabled)
+    dependent.setEnabled(checkbox.isChecked())
+
+
 class WWTOptionPanel(QtWidgets.QWidget):
 
     def __init__(self, viewer_state, session=None, parent=None):
@@ -28,7 +33,31 @@ class WWTOptionPanel(QtWidgets.QWidget):
 
         self._viewer_state.add_callback('mode', self._update_visible_options)
         self._viewer_state.add_callback('frame', self._update_visible_options)
+        self._setup_widget_dependencies()
         self._update_visible_options()
+
+    def _setup_widget_dependencies(self):
+        _set_enabled_from_checkbox(self.ui.bool_alt_az_grid, self.ui.bool_alt_az_text)
+        _set_enabled_from_checkbox(self.ui.bool_alt_az_grid, self.ui.color_alt_az_grid_color)
+        _set_enabled_from_checkbox(self.ui.bool_ecliptic_grid, self.ui.bool_ecliptic_text)
+        _set_enabled_from_checkbox(self.ui.bool_ecliptic_grid, self.ui.color_ecliptic_grid_color)
+        _set_enabled_from_checkbox(self.ui.bool_equatorial_grid, self.ui.bool_equatorial_text)
+        _set_enabled_from_checkbox(self.ui.bool_equatorial_grid, self.ui.color_equatorial_grid_color)
+        _set_enabled_from_checkbox(self.ui.bool_galactic_grid, self.ui.bool_galactic_text)
+        _set_enabled_from_checkbox(self.ui.bool_galactic_grid, self.ui.color_galactic_grid_color)
+        _set_enabled_from_checkbox(self.ui.bool_constellation_figures, self.ui.color_constellation_figure_color)
+        _set_enabled_from_checkbox(self.ui.bool_ecliptic, self.ui.color_ecliptic_color)
+        _set_enabled_from_checkbox(self.ui.bool_precession_chart, self.ui.color_precession_chart_color)
+
+        def enable_if_in(text, options, widget):
+            widget.setEnabled(text in options)
+        self.ui.combosel_constellation_boundaries.currentTextChanged.connect(
+            lambda text: enable_if_in(text, ['All'], self.ui.color_constellation_boundary_color))
+        enable_if_in(self._viewer_state.constellation_boundaries, ['All'], self.ui.color_constellation_boundary_color)
+        self.ui.combosel_constellation_boundaries.currentTextChanged.connect(
+            lambda text: enable_if_in(text, ['All', 'Selection only'], self.ui.color_constellation_selection_color))
+        enable_if_in(self._viewer_state.constellation_boundaries, ['All', 'Selection only'], self.ui.color_constellation_selection_color)
+
 
     def _update_visible_options(self, *args, **kwargs):
 

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>363</width>
-    <height>289</height>
+    <height>342</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,14 +29,25 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="combosel_foreground">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_frame">
+     <property name="text">
+      <string>Frame:</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QComboBox" name="combosel_alt_unit">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="combosel_lat_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
@@ -58,6 +69,80 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="combosel_frame">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="combosel_lon_att">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="combosel_alt_att"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="combosel_mode">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="bool_galactic">
+       <property name="text">
+        <string>Galactic Plane mode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_grid">
+       <property name="text">
+        <string>Show grid</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QComboBox" name="combosel_alt_type">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_constellation">
+       <property name="text">
+        <string>Constellation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_constellation_boundaries">
+       <property name="text">
+        <string>boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_constellation_figures">
+       <property name="text">
+        <string>figures</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_mode">
      <property name="font">
@@ -74,23 +159,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_foreground">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Foreground:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="1">
+   <item row="16" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -102,6 +171,26 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_lon_att">
+     <property name="text">
+      <string>Longitude:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_lat_att">
+     <property name="text">
+      <string>Latitude:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
    </item>
    <item row="12" column="0">
     <widget class="QLabel" name="label_background">
@@ -119,63 +208,10 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="combosel_alt_att"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_lat_att">
-     <property name="text">
-      <string>Latitude:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_lon_att">
-     <property name="text">
-      <string>Longitude:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="QComboBox" name="combosel_background">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="combosel_frame">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_frame">
-     <property name="text">
-      <string>Frame:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="combosel_mode">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+   <item row="6" column="1">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -192,75 +228,45 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="combosel_lat_att">
+   <item row="7" column="1">
+    <widget class="QComboBox" name="combosel_foreground">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="combosel_lon_att">
+   <item row="12" column="1">
+    <widget class="QComboBox" name="combosel_background">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
-   <item row="14" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_galactic">
-       <property name="text">
-        <string>Galactic Plane mode</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="1">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_foreground">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
      </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="combosel_alt_unit">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     <property name="text">
+      <string>Foreground:</string>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QComboBox" name="combosel_alt_type">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToContents</enum>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -85,14 +85,14 @@
      <item>
       <widget class="QCheckBox" name="bool_constellation_boundaries">
        <property name="text">
-        <string>boundaries</string>
+        <string>Boundaries</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="bool_constellation_figures">
        <property name="text">
-        <string>figures</string>
+        <string>Figures</string>
        </property>
       </widget>
      </item>
@@ -100,6 +100,12 @@
    </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_lat_att">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Latitude:</string>
      </property>
@@ -147,6 +153,12 @@
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_lon_att">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Longitude:</string>
      </property>
@@ -157,13 +169,28 @@
    </item>
    <item row="17" column="0">
     <widget class="QLabel" name="label_grids">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Grids:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_frame">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Frame:</string>
      </property>
@@ -239,8 +266,17 @@
    </item>
    <item row="15" column="0">
     <widget class="QLabel" name="label_constellation">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Constellation:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -17,135 +17,14 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="1">
-        <widget class="QComboBox" name="combosel_lat_att">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="combosel_alt_unit">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QComboBox" name="combosel_background">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_mode">
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Mode:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="combosel_frame">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_lat_att">
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Latitude:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_foreground">
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Foreground:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="label_background">
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Background:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_frame">
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Frame:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -157,49 +36,6 @@
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="combosel_lon_att">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QComboBox" name="combosel_alt_type">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToContents</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QSlider" name="value_foreground_opacity">
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="value">
-          <number>50</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QComboBox" name="combosel_foreground">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="combosel_alt_att"/>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_lon_att">
@@ -224,6 +60,27 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="combosel_alt_unit">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QComboBox" name="combosel_alt_type">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToContents</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combosel_frame">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
        <item row="8" column="0">
         <widget class="QLabel" name="label_opacity">
          <property name="font">
@@ -240,10 +97,160 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="7" column="1">
+        <widget class="QComboBox" name="combosel_foreground">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="combosel_alt_att"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_frame">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Frame:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
         <widget class="QCheckBox" name="bool_galactic">
          <property name="text">
           <string>Galactic Plane mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_background">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Background:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QComboBox" name="combosel_background">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_foreground">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Foreground:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_mode">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="combosel_lon_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QSlider" name="value_foreground_opacity">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>50</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_lat_att">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Latitude:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="combosel_lat_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QCheckBox" name="bool_crosshairs">
+         <property name="text">
+          <string>Show crosshairs</string>
          </property>
         </widget>
        </item>
@@ -489,7 +496,14 @@
        <string>Other</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_5">
-       <item row="3" column="1">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_precession_chart">
+         <property name="text">
+          <string>Precession Chart:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -502,66 +516,38 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_ecliptic_2">
-         <property name="text">
-          <string>Ecliptic:</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="1">
-        <widget class="QCheckBox" name="bool_crosshairs">
-         <property name="text">
-          <string>Show</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_precession_chart">
-         <property name="text">
-          <string>Precession Chart:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
         <widget class="QCheckBox" name="bool_ecliptic">
          <property name="text">
           <string>Show</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_crosshairs">
-         <property name="text">
-          <string>Crosshairs:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QCheckBox" name="bool_precession_chart">
-         <property name="text">
-          <string>Show</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="2">
-        <widget class="QColorBox" name="color_crosshairs_color">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
         <widget class="QColorBox" name="color_ecliptic_color">
          <property name="text">
           <string/>
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_ecliptic_2">
+         <property name="text">
+          <string>Ecliptic:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
         <widget class="QColorBox" name="color_precession_chart_color">
          <property name="text">
           <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="bool_precession_chart">
+         <property name="text">
+          <string>Show</string>
          </property>
         </widget>
        </item>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>353</width>
-    <height>389</height>
+    <height>407</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -396,66 +396,35 @@
        <string>Constellations</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="bool_constellation_selection">
-         <property name="text">
-          <string>Show</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_figures">
-         <property name="text">
-          <string>Figures:</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_boundaries">
          <property name="text">
-          <string>Boundaries:</string>
+          <string>Show boundaries:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_selection">
-         <property name="text">
-          <string>Selection:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QCheckBox" name="bool_constellation_figures">
          <property name="text">
           <string>Show</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QCheckBox" name="bool_constellation_pictures">
          <property name="text">
           <string>Show Pictures</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QCheckBox" name="bool_constellation_boundaries">
-         <property name="text">
-          <string>Show</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QCheckBox" name="bool_constellation_labels">
          <property name="text">
           <string>Show Labels</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -468,24 +437,48 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="2">
-        <widget class="QColorBox" name="color_constellation_boundary_color">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
+       <item row="2" column="2">
         <widget class="QColorBox" name="color_constellation_selection_color">
          <property name="text">
           <string/>
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
+       <item row="3" column="2">
         <widget class="QColorBox" name="color_constellation_figure_color">
          <property name="text">
           <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_figures">
+         <property name="text">
+          <string>Figures:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="2">
+        <widget class="QComboBox" name="combosel_constellation_boundaries"/>
+       </item>
+       <item row="1" column="2">
+        <widget class="QColorBox" name="color_constellation_boundary_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_boundary_color">
+         <property name="text">
+          <string>Boundary color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="label_selection_color">
+         <property name="text">
+          <string>Selection color:</string>
          </property>
         </widget>
        </item>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>363</width>
-    <height>342</height>
+    <height>398</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,16 +29,6 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_frame">
-     <property name="text">
-      <string>Frame:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="1">
     <widget class="QComboBox" name="combosel_alt_unit">
      <property name="sizeAdjustPolicy">
@@ -46,15 +36,8 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="combosel_lat_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_opacity">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_mode">
      <property name="font">
       <font>
        <weight>50</weight>
@@ -62,10 +45,24 @@
       </font>
      </property>
      <property name="text">
-      <string>Opacity:</string>
+      <string>Mode:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QComboBox" name="combosel_alt_type">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
@@ -83,50 +80,8 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="combosel_alt_att"/>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="combosel_mode">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="bool_galactic">
-       <property name="text">
-        <string>Galactic Plane mode</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_grid">
-       <property name="text">
-        <string>Show grid</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
-    <widget class="QComboBox" name="combosel_alt_type">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToContents</enum>
-     </property>
-    </widget>
-   </item>
    <item row="15" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_constellation">
-       <property name="text">
-        <string>Constellation</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QCheckBox" name="bool_constellation_boundaries">
        <property name="text">
@@ -143,19 +98,37 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_mode">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_lat_att">
      <property name="text">
-      <string>Mode:</string>
+      <string>Latitude:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="bool_galactic">
+       <property name="text">
+        <string>Galactic Plane mode</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="12" column="1">
+    <widget class="QComboBox" name="combosel_background">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
@@ -182,10 +155,17 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_lat_att">
+   <item row="17" column="0">
+    <widget class="QLabel" name="label_grids">
      <property name="text">
-      <string>Latitude:</string>
+      <string>Grids:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_frame">
+     <property name="text">
+      <string>Frame:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -208,51 +188,31 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_opacity">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Opacity:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
-    <widget class="QSlider" name="value_foreground_opacity">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>50</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="combosel_foreground">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="combosel_mode">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
-    <widget class="QComboBox" name="combosel_background">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="combosel_alt_att"/>
    </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_foreground">
@@ -269,6 +229,82 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="combosel_lat_att">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="QLabel" name="label_constellation">
+     <property name="text">
+      <string>Constellation:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QSlider" name="value_foreground_opacity">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>50</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QCheckBox" name="bool_ecliptic_grid">
+       <property name="text">
+        <string>Equatorial</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_equatorial_grid">
+       <property name="text">
+        <string>Ecliptic</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="combosel_foreground">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QCheckBox" name="bool_alt_az_grid">
+       <property name="text">
+        <string>Alt/Az</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_galactic_grid">
+       <property name="text">
+        <string>Galactic</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -1,349 +1,583 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>WWT</class>
- <widget class="QWidget" name="WWT">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>363</width>
-    <height>398</height>
+    <width>353</width>
+    <height>389</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>4</number>
-   </property>
-   <property name="topMargin">
-    <number>4</number>
-   </property>
-   <property name="rightMargin">
-    <number>4</number>
-   </property>
-   <property name="bottomMargin">
-    <number>4</number>
-   </property>
-   <property name="verticalSpacing">
-    <number>5</number>
-   </property>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="combosel_alt_unit">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QLabel" name="label_mode">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <property name="text">
-      <string>Mode:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="3" column="1">
+        <widget class="QComboBox" name="combosel_lat_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="combosel_alt_unit">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QComboBox" name="combosel_background">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_mode">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combosel_frame">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_lat_att">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Latitude:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_foreground">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Foreground:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_background">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Background:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_frame">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Frame:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>73</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="combosel_lon_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QComboBox" name="combosel_alt_type">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToContents</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QSlider" name="value_foreground_opacity">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>50</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QComboBox" name="combosel_foreground">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="combosel_alt_att"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_lon_att">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Longitude:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="combosel_mode">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_opacity">
+         <property name="font">
+          <font>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Opacity:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QCheckBox" name="bool_galactic">
+         <property name="text">
+          <string>Galactic Plane mode</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Grids</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="2">
+        <widget class="QCheckBox" name="bool_alt_az_grid">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Grid</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QCheckBox" name="bool_alt_az_text">
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QCheckBox" name="bool_ecliptic_text">
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="label_equatorial">
+         <property name="text">
+          <string>Equatorial:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="bool_ecliptic_grid">
+         <property name="text">
+          <string>Grid</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="3">
+        <widget class="QCheckBox" name="bool_equatorial_text">
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="label_alt_az">
+         <property name="text">
+          <string>Alt/Az:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QCheckBox" name="bool_equatorial_grid">
+         <property name="text">
+          <string>Grid</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_ecliptic">
+         <property name="text">
+          <string>Ecliptic:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="label_galactic">
+         <property name="text">
+          <string>Galactic:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QCheckBox" name="bool_galactic_grid">
+         <property name="text">
+          <string>Grid</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QCheckBox" name="bool_galactic_text">
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QColorBox" name="color_alt_az_grid_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QColorBox" name="color_ecliptic_grid_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="QColorBox" name="color_equatorial_grid_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QColorBox" name="color_galactic_grid_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Constellations</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="bool_constellation_selection">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_figures">
+         <property name="text">
+          <string>Figures:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_boundaries">
+         <property name="text">
+          <string>Boundaries:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_selection">
+         <property name="text">
+          <string>Selection:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="bool_constellation_figures">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="bool_constellation_pictures">
+         <property name="text">
+          <string>Show Pictures</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="bool_constellation_boundaries">
+         <property name="text">
+          <string>Show</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="bool_constellation_labels">
+         <property name="text">
+          <string>Show Labels</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="2">
+        <widget class="QColorBox" name="color_constellation_boundary_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QColorBox" name="color_constellation_selection_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QColorBox" name="color_constellation_figure_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>Other</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="3" column="1">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_ecliptic_2">
+         <property name="text">
+          <string>Ecliptic:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="bool_crosshairs">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_precession_chart">
+         <property name="text">
+          <string>Precession Chart:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="bool_ecliptic">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_crosshairs">
+         <property name="text">
+          <string>Crosshairs:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="bool_precession_chart">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QColorBox" name="color_crosshairs_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QColorBox" name="color_ecliptic_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QColorBox" name="color_precession_chart_color">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QComboBox" name="combosel_alt_type">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToContents</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="combosel_frame">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="combosel_lon_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QCheckBox" name="bool_constellation_boundaries">
-       <property name="text">
-        <string>Boundaries</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_constellation_figures">
-       <property name="text">
-        <string>Figures</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_lat_att">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Latitude:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="bool_galactic">
-       <property name="text">
-        <string>Galactic Plane mode</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="12" column="1">
-    <widget class="QComboBox" name="combosel_background">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_lon_att">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Longitude:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="0">
-    <widget class="QLabel" name="label_grids">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Grids:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_frame">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Frame:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_background">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Background:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_opacity">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Opacity:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="combosel_mode">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="combosel_alt_att"/>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_foreground">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Foreground:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="combosel_lat_att">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QLabel" name="label_constellation">
-     <property name="font">
-      <font>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Constellation:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QSlider" name="value_foreground_opacity">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>50</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="bool_ecliptic_grid">
-       <property name="text">
-        <string>Equatorial</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_equatorial_grid">
-       <property name="text">
-        <string>Ecliptic</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="combosel_foreground">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QCheckBox" name="bool_alt_az_grid">
-       <property name="text">
-        <string>Alt/Az</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_galactic_grid">
-       <property name="text">
-        <string>Galactic</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/glue_wwt/viewer/options_widget.ui
+++ b/glue_wwt/viewer/options_widget.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -43,7 +43,7 @@ class WWTDataViewerState(ViewerState):
     equatorial_grid_color = CallbackProperty("white")
     equatorial_text = CallbackProperty(False)
     ecliptic_grid = CallbackProperty(False)
-    ecliptic_grid_color = CallbackProperty("blue")
+    ecliptic_grid_color = CallbackProperty("green")
     ecliptic_text = CallbackProperty(False)
     alt_az_grid = CallbackProperty(False)
     alt_az_grid_color = CallbackProperty("magenta")

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -38,12 +38,35 @@ class WWTDataViewerState(ViewerState):
     background = SelectionCallbackProperty(default_index=8)
 
     galactic = CallbackProperty(False)
+
     equatorial_grid = CallbackProperty(False)
+    equatorial_grid_color = CallbackProperty("white")
+    equatorial_text = CallbackProperty(False)
     ecliptic_grid = CallbackProperty(False)
+    ecliptic_grid_color = CallbackProperty("blue")
+    ecliptic_text = CallbackProperty(False)
     alt_az_grid = CallbackProperty(False)
+    alt_az_grid_color = CallbackProperty("magenta")
+    alt_az_text = CallbackProperty(False)
     galactic_grid = CallbackProperty(False)
+    galactic_grid_color = CallbackProperty("cyan")
+    galactic_text = CallbackProperty(False)
+
     constellation_boundaries = CallbackProperty(False)
+    constellation_boundary_color = CallbackProperty("blue")
+    constellation_selection = CallbackProperty(False)
+    constellation_selection_color = CallbackProperty("yellow")
+    constellation_labels = CallbackProperty(False)
     constellation_figures = CallbackProperty(False)
+    constellation_figure_color = CallbackProperty("red")
+    constellation_pictures = CallbackProperty(False)
+
+    crosshairs = CallbackProperty(False)
+    crosshairs_color = CallbackProperty("white")
+    ecliptic = CallbackProperty(False)
+    ecliptic_color = CallbackProperty("blue")
+    precession_chart = CallbackProperty(False)
+    precession_chart_color = CallbackProperty("orange")
 
     layers = ListCallbackProperty()
 

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -38,7 +38,10 @@ class WWTDataViewerState(ViewerState):
     background = SelectionCallbackProperty(default_index=8)
 
     galactic = CallbackProperty(False)
-    grid = CallbackProperty(False)
+    equatorial_grid = CallbackProperty(False)
+    ecliptic_grid = CallbackProperty(False)
+    alt_az_grid = CallbackProperty(False)
+    galactic_grid = CallbackProperty(False)
     constellation_boundaries = CallbackProperty(False)
     constellation_figures = CallbackProperty(False)
 

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -52,9 +52,8 @@ class WWTDataViewerState(ViewerState):
     galactic_grid_color = CallbackProperty("cyan")
     galactic_text = CallbackProperty(False)
 
-    constellation_boundaries = CallbackProperty(False)
+    constellation_boundaries = SelectionCallbackProperty(default_index=0)
     constellation_boundary_color = CallbackProperty("blue")
-    constellation_selection = CallbackProperty(False)
     constellation_selection_color = CallbackProperty("yellow")
     constellation_labels = CallbackProperty(False)
     constellation_figures = CallbackProperty(False)
@@ -83,6 +82,7 @@ class WWTDataViewerState(ViewerState):
         WWTDataViewerState.frame.set_choices(self, CELESTIAL_FRAMES)
         WWTDataViewerState.alt_unit.set_choices(self, [str(x) for x in ALT_UNITS])
         WWTDataViewerState.alt_type.set_choices(self, ALT_TYPES)
+        WWTDataViewerState.constellation_boundaries.set_choices(self, ['None', 'All', 'Selection only'])
 
         self.add_callback('imagery_layers', self._update_imagery_layers)
 

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -45,7 +45,6 @@ class WWTDataViewerState(ViewerState):
     constellation_boundaries = CallbackProperty(False)
     constellation_figures = CallbackProperty(False)
 
-
     layers = ListCallbackProperty()
 
     # For now we need to include this here otherwise when loading files, the

--- a/glue_wwt/viewer/viewer_state.py
+++ b/glue_wwt/viewer/viewer_state.py
@@ -38,6 +38,10 @@ class WWTDataViewerState(ViewerState):
     background = SelectionCallbackProperty(default_index=8)
 
     galactic = CallbackProperty(False)
+    grid = CallbackProperty(False)
+    constellation_boundaries = CallbackProperty(False)
+    constellation_figures = CallbackProperty(False)
+
 
     layers = ListCallbackProperty()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     echo
     qtpy
     astropy
-    pywwt>=0.6.0
+    pywwt>=0.21.0
 
 [options.package_data]
 glue_wwt.viewer = *.ui, *.html, *.js, *.png


### PR DESCRIPTION
This PR exposes grid and constellation settings from WWT - in particular, the ability to toggle whether constellation properties, constellation boundaries, and several grid types are visible. These toggles are exposing as options in the viewer state, with the updated options widget UI as below:

![Screenshot from 2023-06-27 12-23-28](https://github.com/glue-viz/glue-wwt/assets/14281631/c8b92ef9-4eea-4b54-92f2-926b55bb4be0)
