### PR TITLE
Bump minimum glue-core

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = find:
 setup_requires = setuptools_scm
 install_requires =
     numpy
-    glue-core>=1.0
+    glue-core>=1.13.1
     echo
     astropy
     pywwt>=0.21.0


### PR DESCRIPTION
This PR resolves #99 by bumping the minimum version of `glue-core`. As mentioned in that issue, this will prevent issues that could arise from combining `glue-qt` and older versions of `glue-core`.