### PR TITLE
Avoid using deprecated import from glue-core

### DIFF
--- a/glue_wwt/conftest.py
+++ b/glue_wwt/conftest.py
@@ -17,11 +17,12 @@ def pytest_configure(config):
     # WebEngine widgets require this.
     from pywwt.qt import WWTQtClient  # noqa
 
-    from glue.utils.qt import get_qapp
+    from glue_qt.utils import get_qapp
     app = get_qapp()
 
 
 def pytest_unconfigure(config):
     global app
-    app.quit()
+    if app is not None:
+        app.quit()
     app = None


### PR DESCRIPTION
This removes the last deprecated import from glue-core and also makes pytest_unconfigure more robust to issues in test setup