### PR TITLE
Guess lat/lon columns for viewer when appropriate

### DIFF
--- a/glue_wwt/viewer/data_viewer.py
+++ b/glue_wwt/viewer/data_viewer.py
@@ -7,6 +7,7 @@ import astropy.units as u
 from glue.core.coordinates import WCSCoordinates
 from glue.logger import logger
 from pywwt import ViewerNotAvailableError
+from pywwt.layers import guess_lon_lat_columns
 
 from .image_layer import WWTImageLayerArtist
 from .table_layer import WWTTableLayerArtist
@@ -127,3 +128,13 @@ class WWTDataViewerBase(object):
                 camera_kwargs["roll"] = roll * u.deg
             viewer._wwt.center_on_coordinates(SkyCoord(ra, dec, unit=u.deg), **camera_kwargs)
         return viewer
+
+    def add_data(self, data):
+        add = super().add_data(data)
+        if add and len(self.state.layers) == 1:
+            colnames = [c.label for c in data.components]
+            lon, lat = guess_lon_lat_columns(colnames)
+            if lon is not None and lat is not None:
+                self.state.lon_att = data.id[lon]
+                self.state.lat_att = data.id[lat]
+        return add


### PR DESCRIPTION
I saw #63 and thought that was an interesting idea, so this PR uses the relevant pywwt to resolve #63 by guessing lat/lon columns when appropriate. To me, "when appropriate" means when adding the first data layer to the viewer - if there was already a layer in the viewer, the choice might clash with what's already selected (whether that's from the automatic selection or what the user has selected), and unexpectedly changing the viewer state from what's already there is obviously not ideal.