### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,7 +32,7 @@ jobs:
         # Standard tests
         - linux: py38-test
         - linux: py39-test
-        - linux: py310-test-devdeps
+        - linux: py310-test
         - linux: py311-test
         - linux: py312-test-devdeps
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     devdeps: git+https://github.com/astropy/astropy
     devdeps: git+https://github.com/astropy/reproject
     devdeps: git+https://github.com/glue-viz/glue
+    devdeps: git+https://github.com/glue-viz/glue-qt
 commands =
     test: pip freeze
     test: pytest --pyargs glue_wwt --cov glue_wwt {posargs}


### PR DESCRIPTION
This PR fixes two issues with the CI:
* Use dev version of `glue-qt` for devdeps (to avoid issues like e.g. https://github.com/glue-viz/glue-qt/issues/23)
* astropy has dropped support for Python 3.10 so we can no longer use that Python version for devdeps

These two commits were originally on #103 but they're also needed for e.g. #115 so I decided to make this a separate PR while I work out any other CI issues with #103.
