### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,23 +30,20 @@ jobs:
 
       envs: |
         # Standard tests
-        - linux: py38-test
-        - linux: py39-test
         - linux: py310-test
         - linux: py311-test
-        - linux: py312-test-devdeps
+        - linux: py312-test
+        - linux: py313-test-devdeps
 
-        - macos: py38-test
-        - macos: py39-test
         - macos: py310-test
-        - macos: py311-test-devdeps
+        - macos: py311-test
         - macos: py312-test
+        - macos: py313-test-devdeps
 
-        - windows: py38-test
-        - windows: py39-test
         - windows: py310-test
-        - windows: py311-test-devdeps
+        - windows: py311-test
         - windows: py312-test
+        - windows: py313-test-devdeps
 
   publish:
     needs: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "BSD 3-Clause License"}
 description = "Glue WorldWide Telescope plugin"
 readme = "README.rst"
 urls = {Homepage = "https://github.com/glue-viz/glue-wwt"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "glue-core>=1.13.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-{test,devdeps}
+envlist = py{310,311,312,313}-{test,devdeps}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
 [testenv]
+setenv =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 passenv =
     DISPLAY
     HOME
@@ -12,8 +14,9 @@ changedir =
 extras =
     test: test,qt
 deps =
-    devdeps: git+https://github.com/astropy/astropy
-    devdeps: git+https://github.com/astropy/reproject
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
+    devdeps: reproject>=0.0.dev0
     devdeps: git+https://github.com/glue-viz/glue
     devdeps: git+https://github.com/glue-viz/glue-qt
 commands =


### PR DESCRIPTION
This also updates the CI jobs accordingly and uses wheels where possible for developer dependencies