### PR TITLE
Add pre-commit and ruff codestyle check setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: 'monthly'
+
+exclude:
+  "^(\
+    js/.*|\
+    docs/.*|\
+  )$"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--enforce-all", "--maxkb=800"]
+        exclude: "^(\
+          CHANGES.md|\
+          docs/.*|\
+          js/.*
+        )$"
+        # Prevent giant files from being committed.
+      - id: check-case-conflict
+        # Check for files with names that would conflict on a case-insensitive
+        # filesystem like MacOS HFS+ or Windows FAT.
+      - id: check-json
+        # Attempts to load all json files to verify syntax.
+      - id: check-merge-conflict
+        # Check for files that contain merge conflict strings.
+      - id: check-symlinks
+        # Checks for symlinks which do not point to anything.
+      - id: check-toml
+        # Attempts to load all TOML files to verify syntax.
+      - id: check-xml
+        # Attempto load all xml files to verify syntax.
+      - id: check-yaml
+        # Attempts to load all yaml files to verify syntax.
+        exclude: ".*(.github.*)$"
+      - id: detect-private-key
+        # Checks for the existence of private keys.
+      - id: end-of-file-fixer
+        # Makes sure files end in a newline and only a newline.
+        exclude: ".*(data.*|extern.*|icons.*|licenses.*|_static.*|_parsetab.py|.svg)$"
+      # - id: fix-encoding-pragma  # covered by pyupgrade
+      - id: trailing-whitespace
+        # Trims trailing whitespace.
+        exclude_types: [python]  # Covered by Ruff W291.
+        exclude: ".*(CHANGES.md|data.*|extern.*|licenses.*|_static.*|yso.tbl)$"
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+        # Detect mistake of rst directive not ending with double colon.
+      - id: rst-inline-touching-normal
+        # Detect mistake of inline code touching normal text in rst.
+      - id: text-unicode-replacement-char
+        # Forbid files which have a UTF-8 Unicode replacement character.
+        exclude: "docs/.*\\.(html|glb|gltf|usdz|obj|png|jpg|jpeg)"
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.11.4"
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,6 @@ ci:
   autofix_prs: false
   autoupdate_schedule: 'monthly'
 
-exclude:
-  "^(\
-    js/.*|\
-    docs/.*|\
-  )$"
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -55,8 +49,6 @@ repos:
       - id: rst-inline-touching-normal
         # Detect mistake of inline code touching normal text in rst.
       - id: text-unicode-replacement-char
-        # Forbid files which have a UTF-8 Unicode replacement character.
-        exclude: "docs/.*\\.(html|glb|gltf|usdz|obj|png|jpg|jpeg)"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.11.4"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,6 @@
+lint.ignore = [
+    # NOTE: to find a good code to fix, run:
+    # ruff check --select="ALL" --statistics glue_wwt/<subpackage>
+]
+
+[lint.extend-per-file-ignores]

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,11 @@ commands =
     test: pytest --pyargs glue_wwt --cov glue_wwt {posargs}
 
 [testenv:codestyle]
+skipsdist = true
 skip_install = true
-deps = flake8
+description = Run all style and file checks with pre-commit
+deps =
+    pre-commit
 commands =
-    flake8 --max-line-length=120 glue_wwt
+    pre-commit install-hooks
+    pre-commit run --color always --all-files --show-diff-on-failure


### PR DESCRIPTION
This PR sets up ruff as the codestyle linter for this package and makes it available as a local pre-commit hook.

Following the example of https://github.com/glue-viz/glue/pull/2531, I've added a `.ruff.toml` for any temporary rules to ignore. For this package, though, we actually didn't need to change anything! So it's just a skeleton for the time being.